### PR TITLE
loro 1.10.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - pip
   run:
     - python
+    - libgcc  # [linux]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('rust') }}
+    - {{ compiler('c') }}  # [linux]
     - cargo-bundle-licenses
   host:
     - python
@@ -27,7 +28,6 @@ requirements:
     - pip
   run:
     - python
-    - libgcc  # [linux]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "loro" %}
-{% set version = "1.8.1" %}
+{% set version = "1.10.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 22cfb19625bd7245e9747ee9d43b10511c16a35775a38cf914dc74863c4dbe88
+  sha256: 68184ab1c2ab94af6ad4aaba416d22f579cabee0b26cbb09a1f67858207bbce8
 
 build:
   number: 0


### PR DESCRIPTION
## loro 1.10.3

**Destination channel:** defaults

### Links
- [PKG-15117](https://anaconda.atlassian.net/browse/PKG-15117)
- [PyPI](https://pypi.org/project/loro/1.10.3/)
- [GitHub](https://github.com/loro-dev/loro-py)

### Explanation of changes:
- Updated loro from 1.8.1 to 1.10.3
- Added `libgcc` run dependency on Linux to satisfy `--error-overlinking` (Rust extension links `libgcc_s.so.1`)
- No patch changes; build still uses maturin >=1.8,<2.0 with upstream pytest suite

[PKG-15117]: https://anaconda.atlassian.net/browse/PKG-15117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ